### PR TITLE
Fix obj comparison for selected option

### DIFF
--- a/dropdown.js
+++ b/dropdown.js
@@ -45,7 +45,7 @@ function dropdown(settings) {
         });
         options.appendChild(div);
         opts.push(opt);
-        if ( option === settings.selected ) {
+        if ( JSON.stringify(option) === JSON.stringify(settings.selected) ) {
             setSelection(opt);
         }
     });


### PR DESCRIPTION
Strict comparison between objects fails because of internal javascript comparison by reference.